### PR TITLE
Upgrade to Java 21 and Spring Boot 3.3.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=17-bullseye
+ARG VARIANT=21-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
 ARG NODE_VERSION="none"
@@ -8,6 +8,6 @@ ARG USER=vscode
 VOLUME /home/$USER/.m2
 VOLUME /home/$USER/.gradle
 
-ARG JAVA_VERSION=17.0.4.1-ms
+ARG JAVA_VERSION=21.0.0.3-ms
 RUN sudo mkdir /home/$USER/.m2 /home/$USER/.gradle && sudo chown $USER:$USER /home/$USER/.m2 /home/$USER/.gradle
 RUN bash -lc '. /usr/local/sdkman/bin/sdkman-init.sh && sdk install java $JAVA_VERSION && sdk use java $JAVA_VERSION'

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17' ]
+        java: [ '21' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.2</version>
+    <version>3.3.0</version>
   </parent>
   <name>petclinic</name>
 
   <properties>
 
     <!-- Generic properties -->
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
Upgrades the application to Java 21 and Spring Boot 3.3.0, aligning with the latest standards for improved performance and compatibility.

- **Java and Spring Boot version updates:**
  - Updates the Java version to 21 in `.devcontainer/Dockerfile`, ensuring the development container uses the latest Java version.
  - Modifies `pom.xml` to set the Java version to 21 and the Spring Boot version to 3.3.0, aligning the project dependencies with the latest versions.
- **GitHub Actions workflow adjustment:**
  - Adjusts the Java version in `.github/workflows/maven-build.yml` to use Java 21, ensuring CI/CD processes use the updated Java version.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chrisreddington/spring-petclinic?shareId=2728a3aa-ac74-4614-9b95-468e00eb7b48).