### PR TITLE
Upgrade to Java 21 and Spring Boot 3.3.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=17-bullseye
+ARG VARIANT=21-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
 ARG NODE_VERSION="none"
@@ -8,6 +8,6 @@ ARG USER=vscode
 VOLUME /home/$USER/.m2
 VOLUME /home/$USER/.gradle
 
-ARG JAVA_VERSION=17.0.4.1-ms
+ARG JAVA_VERSION=21.3.0-ms
 RUN sudo mkdir /home/$USER/.m2 /home/$USER/.gradle && sudo chown $USER:$USER /home/$USER/.m2 /home/$USER/.gradle
 RUN bash -lc '. /usr/local/sdkman/bin/sdkman-init.sh && sdk install java $JAVA_VERSION && sdk use java $JAVA_VERSION'

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ '17' ]
+        java: [ '21' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.2</version>
+    <version>3.3.0</version>
   </parent>
   <name>petclinic</name>
 
   <properties>
 
     <!-- Generic properties -->
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
Upgrades the application to Java 21 and Spring Boot 3.3.0, aligning with the latest standards and ensuring compatibility with new features and improvements.

- **Updates Java and Spring Boot versions:** Modifies `pom.xml` to set the Java version to `21` and the Spring Boot version to `3.3.0`, ensuring the application leverages the latest capabilities and features of both Java and Spring Boot.
- **Adjusts GitHub Actions workflow:** Changes the Java version in `.github/workflows/maven-build.yml` to `21` to match the application's updated Java version, ensuring CI processes use the correct Java version.
- **Updates Docker configuration:** Alters `.devcontainer/Dockerfile` by setting the `VARIANT` argument to `21-bullseye` and updating the `ARG JAVA_VERSION` to `21.3.0-ms`, which aligns the development container environment with the new Java version.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/chrisreddington/spring-petclinic?shareId=21e048d7-bb34-4196-974e-909689a5ddc5).